### PR TITLE
Already paginated fix + Test coverage

### DIFF
--- a/lib/wor/paginate/adapters/kaminari.rb
+++ b/lib/wor/paginate/adapters/kaminari.rb
@@ -6,7 +6,7 @@ module Wor
     module Adapters
       class Kaminari < Wor::Paginate::Adapters::Adapter
         def required_methods
-          %i(page per)
+          %i(page)
         end
 
         def paginated_content

--- a/lib/wor/paginate/adapters/kaminari_already_paginated.rb
+++ b/lib/wor/paginate/adapters/kaminari_already_paginated.rb
@@ -12,7 +12,7 @@ module Wor
         end
 
         def paginated_content
-          @content
+          @paginated_content ||= @content.page(@page).per(@limit)
         end
 
         def count

--- a/lib/wor/paginate/adapters/will_paginate_already_paginated.rb
+++ b/lib/wor/paginate/adapters/will_paginate_already_paginated.rb
@@ -15,15 +15,16 @@ module Wor
         end
 
         def paginated_content
-          @content
+          @paginated_content ||= @content.limit(nil).offset(0)
+                                         .paginate(page: @page, per_page: @limit)
         end
 
         def count
-          @content.to_a.size
+          paginated_content.to_a.size
         end
 
         def total_count
-          @content.total_entries
+          paginated_content.total_entries
         end
       end
     end

--- a/lib/wor/paginate/paginate.rb
+++ b/lib/wor/paginate/paginate.rb
@@ -2,8 +2,8 @@ module Wor
   module Paginate
     ADAPTERS = [Adapters::KaminariAlreadyPaginated,
                 Adapters::WillPaginateAlreadyPaginated,
-                Adapters::Kaminari,
                 Adapters::WillPaginate,
+                Adapters::Kaminari,
                 Adapters::Enumerable,
                 Adapters::ActiveRecord].freeze
 

--- a/spec/adapters/adapter_spec.rb
+++ b/spec/adapters/adapter_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'spec_helper'
+RSpec.describe Wor::Paginate::Adapters::Adapter do
+  describe '#index' do
+    context 'when paginating something already paginated' do
+      context 'with results' do
+        let(:adapter) {  Wor::Paginate::Adapters::Adapter.new(DummyModel, 1, 1) }
+
+        it 'throws error when calling required_methods' do
+          expect { adapter.required_methods }.to raise_error(NotImplementedError)
+        end
+        it 'throws error when calling paginated_content' do
+          expect { adapter.paginated_content }.to raise_error(NotImplementedError)
+        end
+        it 'throws error when calling count' do
+          expect { adapter.count }.to raise_error(NotImplementedError)
+        end
+        it 'throws error when calling total_count' do
+          expect { adapter.total_count }.to raise_error(NotImplementedError)
+        end
+      end
+    end
+  end
+end

--- a/spec/adapters/kaminari_spec.rb
+++ b/spec/adapters/kaminari_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'spec_helper'
+RSpec.describe Wor::Paginate::Adapters::Kaminari do
+  describe '#index' do
+    let!(:n) { 28 }
+    let!(:n_page) { 25 }
+    let!(:dummy_models) { create_list(:dummy_model, n) }
+    context 'when paginating something already paginated' do
+      context 'with results' do
+        let!(:paginated) { DummyModel.paginate(page: 1) }
+        let(:adapter) {  Wor::Paginate::Adapters::Kaminari.new(paginated, 1, n_page) }
+        before do
+          allow_any_instance_of(ActiveRecord::Relation).to receive(:per)
+            .and_return(DummyModel.page(1))
+        end
+        it 'responds to count' do
+          expect(adapter.count).to be n_page
+        end
+
+        it 'responds to required_methods' do
+          expect(adapter.required_methods).not_to be_empty
+        end
+
+        it 'responds to total_count' do
+          expect(adapter.total_count).to be n
+        end
+
+        it 'responds to total_pages' do
+          expect(adapter.total_pages).to be 2
+        end
+
+        it 'responds to paginated_content' do
+          expect(adapter.paginated_content.class).to be paginated.class
+        end
+      end
+    end
+  end
+end

--- a/spec/adapters/will_paginate_already_paginated_spec.rb
+++ b/spec/adapters/will_paginate_already_paginated_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require 'spec_helper'
+RSpec.describe Wor::Paginate::Adapters::KaminariAlreadyPaginated do
+  describe '#index' do
+    let!(:n) { 28 }
+    let!(:n_page) { 10 }
+    let!(:dummy_models) { create_list(:dummy_model, n) }
+    context 'when paginating something already paginated' do
+      context 'with no results' do
+        let!(:paginated) { DummyModel.paginate(page: 5) }
+        let(:adapter) do
+          Wor::Paginate::Adapters::WillPaginateAlreadyPaginated.new(paginated, 1, n_page)
+        end
+        it 'responds to count' do
+          expect(adapter.count).to be n_page
+        end
+
+        it 'responds to required_methods' do
+          expect(adapter.required_methods).not_to be_empty
+        end
+
+        it 'responds to total_count' do
+          expect(adapter.total_count).to be n
+        end
+
+        it 'responds to total_pages' do
+          expect(adapter.total_pages).to be 3
+        end
+
+        it 'responds to paginated_content' do
+          expect(adapter.paginated_content.class).to be paginated.class
+        end
+      end
+
+      context 'with results' do
+        let!(:paginated) { DummyModel.paginate(page: 1) }
+        let(:adapter) do
+          Wor::Paginate::Adapters::WillPaginateAlreadyPaginated.new(paginated, 1, n_page)
+        end
+        it 'responds to count' do
+          expect(adapter.count).to be n_page
+        end
+
+        it 'responds to required_methods' do
+          expect(adapter.required_methods).not_to be_empty
+        end
+
+        it 'responds to total_pages' do
+          expect(adapter.total_pages).to be 3
+        end
+
+        it 'responds to total_count' do
+          expect(adapter.total_count).to be n
+        end
+
+        it 'responds to paginated_content' do
+          expect(adapter.paginated_content.class).to be paginated.class
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy_controller_spec.rb
+++ b/spec/dummy_controller_spec.rb
@@ -77,44 +77,6 @@ RSpec.describe DummyModelsController, type: :controller do
         end
       end
     end
-    context 'when paginating an ActiveRecord model with will_paginate installed' do
-      before do
-        allow_any_instance_of(Wor::Paginate::Adapters::Kaminari)
-          .to receive(:adapt?).and_return(false)
-        get :index
-      end
-
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to(
-          be Wor::Paginate::Config.default_per_page
-        )
-      end
-
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq expected_list
-      end
-
-      it 'responds with count' do
-        expect(response_body(response)['count']).to(
-          be Wor::Paginate::Config.default_per_page
-        )
-      end
-
-      it 'responds with total_count' do
-        expect(response_body(response)['total_count']).to be dummy_models.count
-      end
-
-      it 'responds with total_pages' do
-        total_pages = (dummy_models.count / Wor::Paginate::Config.default_per_page.to_f).ceil
-        expect(response_body(response)['total_pages']).to be total_pages
-      end
-
-      it 'responds with page' do
-        expect(response_body(response)['current_page']).to(
-          be Wor::Paginate::Config.default_page
-        )
-      end
-    end
 
     context 'when paginating an ActiveRecord with a scope' do
       before do
@@ -189,14 +151,14 @@ RSpec.describe DummyModelsController, type: :controller do
       end
     end
 
-    context 'when paginating an ActiveRecord paginated with will_paginate' do
+    context 'when paginating an ActiveRecord paginated with kaminari' do
       before do
         get :index_will_paginate
       end
 
       it 'responds with items' do
         expect(response_body(response)['items'].length).to(
-          be Wor::Paginate::Config.default_per_page
+          be(Wor::Paginate::Config.default_per_page)
         )
       end
 
@@ -332,9 +294,5 @@ RSpec.describe DummyModelsController, type: :controller do
         expect(response_body(response)['current']).to be 1
       end
     end
-  end
-
-  def response_body(response)
-    JSON.parse(response.body)
   end
 end


### PR DESCRIPTION
## Summary
- Reimplemented already paginated adapters to ignore original pagination parameters
- Made test coverage 100% for non-config files