### PR TITLE
Change 'items' to 'page'

### DIFF
--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -9,7 +9,7 @@ module Wor
       end
 
       def format
-        { items: serialized_content, count: count, total_pages: total_pages,
+        { page: serialized_content, count: count, total_pages: total_pages,
           total_count: total_count, current_page: current_page }
       end
 

--- a/spec/dummy/app/formatters/custom_formatter.rb
+++ b/spec/dummy/app/formatters/custom_formatter.rb
@@ -1,5 +1,5 @@
 class CustomFormatter < Wor::Paginate::Formatter
   def format
-    { page: serialized_content, current: current_page }
+    { items: serialized_content, current: current_page }
   end
 end

--- a/spec/dummy_controller_spec.rb
+++ b/spec/dummy_controller_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index
       end
 
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to(
+      it 'responds with page' do
+        expect(response_body(response)['page'].length).to(
           be Wor::Paginate::Config.default_per_page
         )
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq expected_list
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
       end
 
       it 'responds with count' do
@@ -52,12 +52,12 @@ RSpec.describe DummyModelsController, type: :controller do
           get :index_with_params
         end
 
-        it 'responds with items' do
-          expect(response_body(response)['items'].length).to be 1
+        it 'responds with page' do
+          expect(response_body(response)['page'].length).to be 1
         end
 
-        it 'responds with valid items' do
-          expect(response_body(response)['items']).to eq expected_list
+        it 'responds with valid page' do
+          expect(response_body(response)['page']).to eq expected_list
         end
 
         it 'responds with count' do
@@ -84,14 +84,14 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index_scoped
       end
 
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to(
+      it 'responds with page' do
+        expect(response_body(response)['page'].length).to(
           be Wor::Paginate::Config.default_per_page
         )
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq expected_list
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
       end
 
       it 'responds with count' do
@@ -119,14 +119,14 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index_kaminari
       end
 
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to(
+      it 'responds with page' do
+        expect(response_body(response)['page'].length).to(
           be(Wor::Paginate::Config.default_per_page)
         )
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq expected_list
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
       end
 
       it 'responds with count' do
@@ -156,14 +156,14 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index_will_paginate
       end
 
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to(
+      it 'responds with page' do
+        expect(response_body(response)['page'].length).to(
           be(Wor::Paginate::Config.default_per_page)
         )
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq expected_list
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
       end
 
       it 'responds with count' do
@@ -193,12 +193,12 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index_array
       end
 
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to be
+      it 'responds with page' do
+        expect(response_body(response)['page'].length).to be
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq((1..25).to_a)
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq((1..25).to_a)
       end
 
       it 'responds with count' do
@@ -239,12 +239,12 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index_each_serializer
       end
 
-      it 'responds with items' do
-        expect(response_body(response)['items'].length).to be 25
+      it 'responds with page' do
+        expect(response_body(response)['page'].length).to be 25
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['items']).to eq expected_list
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
       end
 
       it 'responds with count' do
@@ -282,12 +282,12 @@ RSpec.describe DummyModelsController, type: :controller do
         get :index_custom_formatter
       end
 
-      it 'doesn\'t responds with items in the default key' do
-        expect(response_body(response)['items']).to be_nil
+      it 'doesn\'t respond with page in the default key' do
+        expect(response_body(response)['page']).to be_nil
       end
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
+      it 'responds with valid page' do
+        expect(response_body(response)['items']).to eq expected_list
       end
 
       it 'responds with page' do


### PR DESCRIPTION
## Summary
Changed 'items' key to 'page' in the default formatter

## Issue
#5 