### PR TITLE
defined matchers for rspec

### DIFF
--- a/lib/wor/paginate/rspec.rb
+++ b/lib/wor/paginate/rspec.rb
@@ -1,0 +1,47 @@
+class MockedAdapter < Wor::Paginate::Adapters::Adapter
+  def initialize; end
+
+  def count
+    3
+  end
+
+  def total_count
+    5
+  end
+
+  def total_pages
+    10
+  end
+
+  def next_page
+    2
+  end
+
+  def page
+    1
+  end
+
+  def paginated_content
+    []
+  end
+end
+
+RSpec::Matchers.define :be_paginated do
+  match do |actual_response|
+    formatter = @custom_formatter || Wor::Paginate::Formatter
+    @formatted_keys = formatter.new(MockedAdapter.new).format.as_json.keys
+    actual_response.keys == @formatted_keys
+  end
+
+  chain :with do |custom_formatter|
+    @custom_formatter = custom_formatter
+  end
+
+  failure_message do |actual_response|
+    "expected that #{actual_response} to be paginated with keys #{@formatted_keys}"
+  end
+
+  failure_message_when_negated do |actual_response|
+    "expected that #{actual_response} not to be paginated with keys #{@formatted_keys}"
+  end
+end

--- a/spec/dummy_controller_spec.rb
+++ b/spec/dummy_controller_spec.rb
@@ -335,10 +335,6 @@ RSpec.describe DummyModelsController, type: :controller do
       end
     end
 
-    def response_body(response)
-      JSON.parse(response.body)
-    end
-
     context 'when paginating an ActiveRecord with a custom formatter' do
       let(:expected_list) do
         dummy_models.first(25).map do |dummy|

--- a/spec/dummy_controller_without_gems_spec.rb
+++ b/spec/dummy_controller_without_gems_spec.rb
@@ -263,6 +263,3 @@ RSpec.describe DummyModelsWithoutGemsController, type: :controller do
     end
   end
 end
-def response_body(response)
-  JSON.parse(response.body)
-end

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe DummyModelsController, type: :controller do
+  let!(:model_count) { 28 }
+  let!(:dummy_models) { create_list(:dummy_model, model_count) }
+  let(:expected_list) do
+    dummy_models.first(25).map do |dummy|
+      { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
+    end
+  end
+
+  describe '#be_paginated' do
+    it 'checks that the response keys matches with the default formatter' do
+      get :index
+      expect(response_body(response)).to be_paginated
+    end
+
+    it 'checks that the response is not paginated with the default formatter' do
+      get :index_custom_formatter
+      expect(response_body(response)).not_to be_paginated
+    end
+  end
+
+  describe '#be_paginated.with' do
+    it 'checks that the response keys matches with the custom formatter' do
+      get :index_custom_formatter
+      expect(response_body(response)).to be_paginated.with(CustomFormatter)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@ require 'simplecov'
 SimpleCov.start
 
 require File.expand_path('../../spec/dummy/config/environment.rb', __FILE__)
+require 'support/response_helper'
+require 'wor/paginate/rspec'
+
 ActiveRecord::Migrator.migrations_paths = [File.expand_path('../../spec/dummy/db/migrate', __FILE__)]
 RSpec.configure do |config|
   config.before(:suite) do
@@ -18,6 +21,7 @@ end
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+  config.include Response::JSONParser, type: :controller
 end
 
 require 'rspec/rails'

--- a/spec/support/response_helper.rb
+++ b/spec/support/response_helper.rb
@@ -1,0 +1,7 @@
+module Response
+  module JSONParser
+    def response_body(response)
+      JSON.parse(response.body)
+    end
+  end
+end


### PR DESCRIPTION
### Summary
- Defined be_paginated and be_paginated.with(formatter) matchers
- Addes specs that checks that both matchers works properly. It also checks that the expect.not_to works properly