### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can use the `be_paginated` matcher to test your endpoints. It also accepts t
 
 You only need to add this in your rails_helper.rb
 ```
-# spec/spec_helper.rb
+# spec/rails_helper.rb
 require 'wor/paginate/rspec'
 ```
 And in your spec do

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If either Kaminari or will_paginate are required in the project, Wor::Paginate w
 ### Test helpers
 You can use the `be_paginated` matcher to test your endpoints. It also accepts the `with` chain method to receive a formatter.
 
-You only need to add this in your spec_helper.rb (or rails_helper.rb)
+You only need to add this in your rails_helper.rb
 ```
 # spec/spec_helper.rb
 require 'wor/paginate/rspec'


### PR DESCRIPTION
# Summary
- Changed location for the helper require, it explodes when you use spec_helper instead of rails_helper