### PR TITLE
Fix options sent to each serializer

### DIFF
--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -32,7 +32,7 @@ module Wor
       end
 
       def serialized_content
-        return paginated_content.map { |item| serializer.new(item) } if serializer.present?
+        return paginated_content.map { |item| serializer.new(item, options) } if serializer.present?
 
         if defined? ActiveModelSerializers::SerializableResource
           ActiveModelSerializers::SerializableResource.new(paginated_content).as_json


### PR DESCRIPTION
When you send to paginate a collection, the serializer doesn't get the options. This fixes that problem.

```
render_paginated(
   collection,
   each_serializer: SomeSerializer,
   option_1: 'some value',
   option_2: 'other value'
)
```