### PR TITLE
Group by fix

### DIFF
--- a/lib/wor/paginate/adapters/active_record.rb
+++ b/lib/wor/paginate/adapters/active_record.rb
@@ -1,3 +1,5 @@
+require_relative 'helpers/total_count'
+
 # Used when render_paginated is called with an ActiveRecord directly, without a
 # pagination gem like kaminari or will_paginate
 ### render_paginated DummyModel
@@ -5,6 +7,8 @@ module Wor
   module Paginate
     module Adapters
       class ActiveRecord < Base
+        include Helpers::TotalCount
+
         attr_reader :page
 
         def required_methods
@@ -17,14 +21,6 @@ module Wor
 
         def count
           paginated_content.size
-        end
-
-        def total_count
-          content = @content.reorder(nil)
-          content_size = content.try(:size)
-          return content.to_a.size if content_size.is_a? Hash
-
-          content.count
         end
 
         def total_pages

--- a/lib/wor/paginate/adapters/active_record.rb
+++ b/lib/wor/paginate/adapters/active_record.rb
@@ -15,10 +15,16 @@ module Wor
           @paginated_content ||= @content.offset(offset).limit(@limit)
         end
 
-        delegate :count, to: :paginated_content
+        def count
+          paginated_content.size
+        end
 
         def total_count
-          @content.count
+          content = @content.reorder(nil)
+          content_size = content.try(:size)
+          return content_size.count if content_size.is_a? Hash
+
+          content.count
         end
 
         def total_pages

--- a/lib/wor/paginate/adapters/active_record.rb
+++ b/lib/wor/paginate/adapters/active_record.rb
@@ -22,7 +22,7 @@ module Wor
         def total_count
           content = @content.reorder(nil)
           content_size = content.try(:size)
-          return content_size.count if content_size.is_a? Hash
+          return content.to_a.size if content_size.is_a? Hash
 
           content.count
         end

--- a/lib/wor/paginate/adapters/helpers/total_count.rb
+++ b/lib/wor/paginate/adapters/helpers/total_count.rb
@@ -1,0 +1,17 @@
+module Wor
+  module Paginate
+    module Adapters
+      module Helpers
+        module TotalCount
+          def total_count
+            content = @content.reorder(nil)
+            content_size = content.try(:size)
+            return content.to_a.size if content_size.is_a? Hash
+
+            content.count
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wor/paginate/adapters/helpers/total_count.rb
+++ b/lib/wor/paginate/adapters/helpers/total_count.rb
@@ -5,10 +5,10 @@ module Wor
         module TotalCount
           def total_count
             content = @content.reorder(nil)
-            content_size = content.try(:size)
+            content_size = content.size
             return content.to_a.size if content_size.is_a? Hash
 
-            content.count
+            content_size
           end
         end
       end

--- a/lib/wor/paginate/adapters/will_paginate.rb
+++ b/lib/wor/paginate/adapters/will_paginate.rb
@@ -20,7 +20,9 @@ module Wor
         end
 
         def total_count
-          paginated_content.count
+          count = paginated_content.count
+          return count.size if count.is_a? Hash
+          count
         end
 
         delegate :total_pages, :next_page, to: :paginated_content

--- a/lib/wor/paginate/adapters/will_paginate.rb
+++ b/lib/wor/paginate/adapters/will_paginate.rb
@@ -1,3 +1,5 @@
+require_relative 'helpers/total_count'
+
 # Used when render_paginated is called with an ActiveModel directly, with will_paginate
 # already required. Something like
 ### render_paginated DummyModel
@@ -5,6 +7,8 @@ module Wor
   module Paginate
     module Adapters
       class WillPaginate < Base
+        include Helpers::TotalCount
+
         attr_reader :page
 
         def required_methods
@@ -17,12 +21,6 @@ module Wor
 
         def count
           paginated_content.to_a.size
-        end
-
-        def total_count
-          count = paginated_content.count
-          return count.size if count.is_a? Hash
-          count
         end
 
         delegate :total_pages, :next_page, to: :paginated_content

--- a/spec/dummy/app/controllers/dummy_models_controller.rb
+++ b/spec/dummy/app/controllers/dummy_models_controller.rb
@@ -40,4 +40,8 @@ class DummyModelsController < ApplicationController
   def index_custom_formatter
     render_paginated DummyModel, formatter: CustomFormatter
   end
+
+  def index_group_by
+    render_paginated DummyModel.ocurrences_of_name
+  end
 end

--- a/spec/dummy/app/models/dummy_model.rb
+++ b/spec/dummy/app/models/dummy_model.rb
@@ -1,4 +1,10 @@
 class DummyModel < ApplicationRecord
   scope :some_scope, -> { where('something >= 0') }
   has_many :dummy_model_sons, dependent: :nullify
+
+  scope :ocurrences_of_name, lambda {
+    select('name, count(*) as count')
+      .group('name')
+      .order('count desc')
+  }
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       get 'index_with_high_limit'
       get 'index_each_serializer'
       get 'index_custom_formatter'
+      get 'index_group_by'
     end
   end
 

--- a/spec/dummy_controller_spec.rb
+++ b/spec/dummy_controller_spec.rb
@@ -373,5 +373,25 @@ describe DummyModelsController, type: :controller do
         expect(response_body(response)['items']).to eq expected_list
       end
     end
+
+    context 'when paginating an ActiveRecord with a group by query' do
+      let!(:dummy_models) { create_list(:dummy_model, 12, name: 'argentina') }
+      let!(:dummy_models_2) { create_list(:dummy_model, 10, name: 'uruguay') }
+      let!(:dummy_models_3) { create_list(:dummy_model, 18, name: 'costa rica') }
+
+      let(:limit) { 2 }
+
+      before do
+        get :index_group_by, params: { per: limit }
+      end
+
+      it 'responds with a page with expected length' do
+        expect(response_body(response)['page'].length).to eq 2
+      end
+
+      it 'responds with valid total count' do
+        expect(response_body(response)['total_count']).to eq 3
+      end
+    end
   end
 end

--- a/spec/dummy_controller_spec.rb
+++ b/spec/dummy_controller_spec.rb
@@ -375,9 +375,9 @@ describe DummyModelsController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord with a group by query' do
-      let!(:dummy_models) { create_list(:dummy_model, 12, name: 'argentina') }
-      let!(:dummy_models_2) { create_list(:dummy_model, 10, name: 'uruguay') }
-      let!(:dummy_models_3) { create_list(:dummy_model, 18, name: 'costa rica') }
+      let!(:dummy_models) { create_list(:dummy_model, 1, name: 'argentina') }
+      let!(:dummy_models_2) { create_list(:dummy_model, 2, name: 'uruguay') }
+      let!(:dummy_models_3) { create_list(:dummy_model, 3, name: 'costa rica') }
 
       let(:limit) { 2 }
 


### PR DESCRIPTION
# Summary
- #64 Now pagination can be used with queries with `group by`.