### PR TITLE
Fixed Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: ruby
 rvm:
-  - 2.3.3
-  - 2.4.0
-  - 2.4.2
-  - 2.5.0
+  - 2.3.8
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
   - ruby-head
 
-install:
+before_install:
   - gem install bundler -v 1.16.4
+
+install:
   - bundle _1.16.4_ install --retry=3
   - bundle exec rake db:migrate RAILS_ENV=test -f spec/dummy/Rakefile
 
@@ -15,3 +17,7 @@ script:
   - bundle exec rubocop lib spec --format simple
   - bundle exec rspec
   - bundle exec codeclimate-test-reporter
+
+matrix:
+  allow_failures:
+    - rvm : ruby-head

--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -32,8 +32,9 @@ module Wor
       end
 
       def serialized_content
-        return paginated_content.map { |item| serializer.new(item, scope: options[:scope]) } if serializer.present?
-
+        if serializer.present?
+          return paginated_content.map { |item| serializer.new(item, scope: options[:scope]) }
+        end
         if defined? ActiveModelSerializers::SerializableResource
           ActiveModelSerializers::SerializableResource.new(paginated_content).as_json
         else


### PR DESCRIPTION
- Fixed rubocop
- Allowing ruby 2.7.0-dev build to fail. This is because it was failing due to a method called inside activerecord gem.