### PR TITLE
Fixing sprockets error manifest not found

### DIFF
--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,6 @@
+// app/assets/config/manifest.js
+//
+//= link application.css
+//= link marketing.css
+//
+//= link application.js


### PR DESCRIPTION
## Summary
- Added `manifest.js` to support sprockets 4.0 on tests.
