### PR TITLE
Delete max Railties dependency in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change log
 
+### V0.1.8
+* [#85](https://github.com/Wolox/wor-paginate/pull/85) Delete max Railties dependency in gemspec - [@lucasvoboril](https://github.com/lucasvoboril).
+
 ### V0.1.7
 * [#61](https://github.com/Wolox/wor-paginate/pull/61) Allows requests on offset pages for enumerables - [@mtejedorwolox](https://github.com/mtejedorwolox).
 * [#63](https://github.com/Wolox/wor-paginate/pull/63) Add max_limit with optional parameter - [@blacksam07](https://github.com/blacksam07).

--- a/lib/wor/paginate/version.rb
+++ b/lib/wor/paginate/version.rb
@@ -1,5 +1,5 @@
 module Wor
   module Paginate
-    VERSION = '0.1.7'.freeze
+    VERSION = '0.1.8'.freeze
   end
 end

--- a/wor-paginate.gemspec
+++ b/wor-paginate.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
 
-  s.add_dependency 'railties', '>= 4.1.0', "<= 6.0.0"
+  s.add_dependency 'railties', '>= 4.1.0'
   s.add_dependency 'rails', '>= 4.0'
 end


### PR DESCRIPTION
## Summary

* Delete Railties max version dependence in gemspec

<details><summary>Dependency problems</summary>
<p>

```
Bundler could not find compatible versions for gem "railties":
  In snapshot (Gemfile.lock):
    railties (= 6.0.1)

  In Gemfile:
    devise (~> 4.7.0) was resolved to 4.7.1, which depends on
      railties (>= 4.1.0)

    health_check (~> 3.0) was resolved to 3.0.0, which depends on
      railties (>= 5.0)

    jquery-rails (~> 4.3.5) was resolved to 4.3.5, which depends on
      railties (>= 4.2.0)

    rails (~> 6.0.1) was resolved to 6.0.1, which depends on
      railties (= 6.0.1)

    wor-paginate was resolved to 0.1.0, which depends on
      railties (>= 4.1.0, <= 5.1)
```

</p>
</details>
