### PR TITLE
Supporting expect(response).to be_paginated

### DIFF
--- a/lib/wor/paginate/rspec.rb
+++ b/lib/wor/paginate/rspec.rb
@@ -28,9 +28,14 @@ end
 
 RSpec::Matchers.define :be_paginated do
   match do |actual_response|
+    response = parse_response(actual_response)
     formatter = @custom_formatter || Wor::Paginate::Formatter
     @formatted_keys = formatter.new(MockedAdapter.new).format.as_json.keys
-    actual_response.keys == @formatted_keys
+    response.keys == @formatted_keys
+  end
+
+  def parse_response(response)
+    response.is_a?(Hash) ? response : JSON.parse(response.body)
   end
 
   chain :with do |custom_formatter|
@@ -38,10 +43,11 @@ RSpec::Matchers.define :be_paginated do
   end
 
   failure_message do |actual_response|
-    "expected that #{actual_response} to be paginated with keys #{@formatted_keys}"
+    "expected that #{parse_response(actual_response)} to be paginated with keys #{@formatted_keys}"
   end
 
   failure_message_when_negated do |actual_response|
-    "expected that #{actual_response} not to be paginated with keys #{@formatted_keys}"
+    "expected that #{parse_response(actual_response)} not " \
+     "to be paginated with keys #{@formatted_keys}"
   end
 end

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -10,21 +10,44 @@ describe DummyModelsController, type: :controller do
   end
 
   describe '#be_paginated' do
-    it 'checks that the response keys matches with the default formatter' do
-      get :index
-      expect(response_body(response)).to be_paginated
+    context 'when using response_body' do
+      it 'checks that the response keys matches with the default formatter' do
+        get :index
+        expect(response_body(response)).to be_paginated
+      end
+
+      it 'checks that the response is not paginated with the default formatter' do
+        get :index_custom_formatter
+        expect(response_body(response)).not_to be_paginated
+      end
     end
 
-    it 'checks that the response is not paginated with the default formatter' do
-      get :index_custom_formatter
-      expect(response_body(response)).not_to be_paginated
+    context 'when using response' do
+      it 'checks that the response keys matches with the default formatter' do
+        get :index
+        expect(response).to be_paginated
+      end
+
+      it 'checks that the response is not paginated with the default formatter' do
+        get :index_custom_formatter
+        expect(response).not_to be_paginated
+      end
     end
   end
 
   describe '#be_paginated.with' do
-    it 'checks that the response keys matches with the custom formatter' do
-      get :index_custom_formatter
-      expect(response_body(response)).to be_paginated.with(CustomFormatter)
+    context 'when using response_body' do
+      it 'checks that the response keys matches with the custom formatter' do
+        get :index_custom_formatter
+        expect(response_body(response)).to be_paginated.with(CustomFormatter)
+      end
+    end
+
+    context 'when using response' do
+      it 'checks that the response keys matches with the custom formatter' do
+        get :index_custom_formatter
+        expect(response).to be_paginated.with(CustomFormatter)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Added support for `expect(response).to be_paginated`. (See #84).
- Supporting hash objects to be passed to be_paginated matcher for backward compatibility.