### PR TITLE
Navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ The response to the index will then be:
   "total_count": 28,
   "current_page": 1,
   "previous_page": null,
-  "next_page": 2
+  "next_page": 2,
+  "previous_page_url": null,
+  "next_page_url": "http://api.example.com/users?page=2
 }
 ```
 

--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -53,15 +53,17 @@ module Wor
       end
 
       def next_page_url
-        return nil unless next_page
-
-        replace_query_params(current_url, page: next_page)
+        page_url(next_page)
       end
 
       def previous_page_url
-        return nil unless previous_page
+        page_url(previous_page)
+      end
 
-        replace_query_params(current_url, page: previous_page)
+      def page_url(page)
+        return nil unless page
+
+        replace_query_params(current_url, page: page)
       end
 
       def current_url

--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -8,7 +8,7 @@ module Wor
         @options = options
       end
 
-      def format
+      def format # rubocop:disable Metrics/MethodLength
         {
           page: serialized_content,
           count: count,
@@ -16,7 +16,9 @@ module Wor
           total_count: total_count,
           current_page: current_page,
           previous_page: previous_page,
-          next_page: next_page
+          next_page: next_page,
+          next_page_url: options[:_links][:next_page_url],
+          previous_page_url: options[:_links][:previous_page_url]
         }
       end
 

--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -1,6 +1,9 @@
+require_relative 'utils/uri_helper'
+
 module Wor
   module Paginate
     class Formatter
+      include Utils::UriHelper
       attr_accessor :adapter, :content, :formatter, :options
 
       def initialize(adapter, options = {})
@@ -8,7 +11,7 @@ module Wor
         @options = options
       end
 
-      def format # rubocop:disable Metrics/MethodLength
+      def format # rubocop: disable Metrics/MethodLength
         {
           page: serialized_content,
           count: count,
@@ -17,8 +20,8 @@ module Wor
           current_page: current_page,
           previous_page: previous_page,
           next_page: next_page,
-          next_page_url: options[:_links][:next_page_url],
-          previous_page_url: options[:_links][:previous_page_url]
+          next_page_url: next_page_url,
+          previous_page_url: previous_page_url
         }
       end
 
@@ -47,6 +50,22 @@ module Wor
 
       def serializer
         options[:each_serializer]
+      end
+
+      def next_page_url
+        return nil unless next_page
+
+        replace_query_params(current_url, page: next_page)
+      end
+
+      def previous_page_url
+        return nil unless previous_page
+
+        replace_query_params(current_url, page: previous_page)
+      end
+
+      def current_url
+        options[:_current_url]
       end
     end
   end

--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -20,8 +20,8 @@ module Wor
           current_page: current_page,
           previous_page: previous_page,
           next_page: next_page,
-          next_page_url: next_page_url,
-          previous_page_url: previous_page_url
+          next_page_url: page_url(next_page),
+          previous_page_url: page_url(previous_page)
         }
       end
 
@@ -50,14 +50,6 @@ module Wor
 
       def serializer
         options[:each_serializer]
-      end
-
-      def next_page_url
-        page_url(next_page)
-      end
-
-      def previous_page_url
-        page_url(previous_page)
       end
 
       def page_url(page)

--- a/lib/wor/paginate/paginate.rb
+++ b/lib/wor/paginate/paginate.rb
@@ -20,10 +20,8 @@ module Wor
     def paginate(content, options = {})
       adapter = find_adapter_for_content(content, options)
       raise Exceptions::NoPaginationAdapter if adapter.blank?
-      formatter_class(options).new(adapter, options.merge(_links: {
-                                                            next_page_url: next_page_url,
-                                                            previous_page_url: previous_page_url
-                                                          })).format
+      formatter_class(options).new(adapter, options.merge(_current_url: request.original_url))
+                              .format
     end
 
     def render_paginate_with_include(content, options)

--- a/lib/wor/paginate/paginate.rb
+++ b/lib/wor/paginate/paginate.rb
@@ -20,7 +20,10 @@ module Wor
     def paginate(content, options = {})
       adapter = find_adapter_for_content(content, options)
       raise Exceptions::NoPaginationAdapter if adapter.blank?
-      formatter_class(options).new(adapter, options).format
+      formatter_class(options).new(adapter, options.merge(_links: {
+                                                            next_page_url: next_page_url,
+                                                            previous_page_url: previous_page_url
+                                                          })).format
     end
 
     def render_paginate_with_include(content, options)

--- a/lib/wor/paginate/rspec.rb
+++ b/lib/wor/paginate/rspec.rb
@@ -30,7 +30,7 @@ RSpec::Matchers.define :be_paginated do
   match do |actual_response|
     response = parse_response(actual_response)
     formatter = @custom_formatter || Wor::Paginate::Formatter
-    @formatted_keys = formatter.new(MockedAdapter.new).format.as_json.keys
+    @formatted_keys = formatter.new(MockedAdapter.new, _current_url: 'http://exaple.com/').format.as_json.keys
     response.keys == @formatted_keys
   end
 

--- a/lib/wor/paginate/utils/uri_helper.rb
+++ b/lib/wor/paginate/utils/uri_helper.rb
@@ -1,0 +1,16 @@
+module Wor
+  module Paginate
+    module Utils
+      module UriHelper
+        def replace_query_params(uri_string, new_query)
+          uri = URI.parse(uri_string)
+          query = Rack::Utils.parse_query(uri.query)
+          uri.query = Rack::Utils.build_query(query.with_indifferent_access.merge(new_query))
+          uri.to_s
+        end
+
+        module_function :replace_query_params
+      end
+    end
+  end
+end

--- a/spec/support/helpers/uri_parser.rb
+++ b/spec/support/helpers/uri_parser.rb
@@ -1,0 +1,9 @@
+module UriParser
+  def get_page_from(uri)
+    return nil if uri.nil?
+
+    Rack::Utils.parse_query(URI.parse(uri).query)['page'].to_i
+  end
+
+  module_function :get_page_from
+end

--- a/spec/support/shared_examples/proper_pagination_params.rb
+++ b/spec/support/shared_examples/proper_pagination_params.rb
@@ -26,4 +26,20 @@ shared_examples 'proper pagination params' do
   it 'responds with next_page' do
     expect(response_body(response)['next_page']).to be pagination_params[:next_page]
   end
+
+  get_page_from_uri = lambda { |uri|
+    uri ? Rack::Utils.parse_query(URI.parse(uri).query)['page'].to_i : nil
+  }
+
+  it 'responds with previous_page_url' do
+    uri = response_body(response)['previous_page_url']
+    page = get_page_from_uri.call(uri)
+    expect(page).to be pagination_params[:previous_page]
+  end
+
+  it 'responds with next_page_url' do
+    uri = response_body(response)['next_page_url']
+    page = get_page_from_uri.call(uri)
+    expect(page).to be pagination_params[:next_page]
+  end
 end

--- a/spec/support/shared_examples/proper_pagination_params.rb
+++ b/spec/support/shared_examples/proper_pagination_params.rb
@@ -1,3 +1,5 @@
+require_relative '../helpers/uri_parser.rb'
+
 shared_examples 'proper pagination params' do
   it 'responds with page' do
     expect(response_body(response)['page'].length).to be pagination_params[:page]
@@ -27,19 +29,15 @@ shared_examples 'proper pagination params' do
     expect(response_body(response)['next_page']).to be pagination_params[:next_page]
   end
 
-  get_page_from_uri = lambda { |uri|
-    uri ? Rack::Utils.parse_query(URI.parse(uri).query)['page'].to_i : nil
-  }
-
   it 'responds with previous_page_url' do
     uri = response_body(response)['previous_page_url']
-    page = get_page_from_uri.call(uri)
+    page = UriParser.get_page_from(uri)
     expect(page).to be pagination_params[:previous_page]
   end
 
   it 'responds with next_page_url' do
     uri = response_body(response)['next_page_url']
-    page = get_page_from_uri.call(uri)
+    page = UriParser.get_page_from(uri)
     expect(page).to be pagination_params[:next_page]
   end
 end

--- a/spec/wor/paginate/utils/uri_helper_spec.rb
+++ b/spec/wor/paginate/utils/uri_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'wor/paginate/utils/uri_helper'
+
+describe Wor::Paginate::Utils::UriHelper do
+  describe '.replace_query_params' do
+    subject(:replace_query_params) { described_class.replace_query_params(uri, new_query) }
+
+    let(:uri) { 'example.com/users?page=1&name=3' }
+
+    context 'without repeated params' do
+      let(:new_query) { { age: 21 } }
+
+      it 'returns the expected uri' do
+        expect(replace_query_params).to eq 'example.com/users?page=1&name=3&age=21'
+      end
+    end
+
+    context 'when repeating params' do
+      let(:new_query) { { age: 21, page: 2 } }
+
+      it 'returns the expected uri' do
+        expect(replace_query_params).to eq 'example.com/users?page=2&name=3&age=21'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Added `previous_page_url` and `next_page_url` on responses.
- Keeps query params sent in request and overwrites page.
- Solves #67 
