### PR TITLE
Added Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4.7
   - 2.5.6
   - 2.6.4
+  - 2.7.0
   - ruby-head
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ end
 ## About ##
 
 The current maintainers of this gem are :
-* [Lucas Voboril](https://github.com/lucasVoboril)
 * [Martín Mallea](https://github.com/mnmallea)
 
 This project was developed by:


### PR DESCRIPTION
## Summary
- Added ruby 2.7.0 on ci builds. (Now `ruby-head` targets to 2.8.0dev).
- Updated manteiners.