### PR TITLE
Added total_count option to overwrite the count in render_paginated

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ class CustomSerializer < ActiveModel::Serializer
 end
 ```
 
+##### total_count
+You can overwrite the `total_count` pagination param by passing it as a single option to the method. This could be used if the whole collection to be paginated is complex and has the risk to broke when counting all the records.
+
+```ruby
+  render_paginated DummyModel, total_count: 50
+```
+
 #### Custom formatters
 A formatter is an object that defines the output of the render_paginated method. In case the application needs a different format for a request, it can be passed to the `render_paginated` method using the `formatter` option:
 ```ruby

--- a/lib/wor/paginate/formatter.rb
+++ b/lib/wor/paginate/formatter.rb
@@ -16,7 +16,7 @@ module Wor
           page: serialized_content,
           count: count,
           total_pages: total_pages,
-          total_count: total_count,
+          total_count: options[:total_count] || total_count,
           current_page: current_page,
           previous_page: previous_page,
           next_page: next_page,

--- a/lib/wor/paginate/paginate.rb
+++ b/lib/wor/paginate/paginate.rb
@@ -20,6 +20,7 @@ module Wor
     def paginate(content, options = {})
       adapter = find_adapter_for_content(content, options)
       raise Exceptions::NoPaginationAdapter if adapter.blank?
+
       formatter_class(options).new(adapter, options.merge(_current_url: request.original_url))
                               .format
     end
@@ -45,15 +46,15 @@ module Wor
     end
 
     def option_limit(options)
-      options[:limit].to_i unless options[:limit].nil?
+      options[:limit]&.to_i
     end
 
     def option_max_limit(options)
-      options[:max_limit].to_i unless options[:max_limit].nil?
+      options[:max_limit]&.to_i
     end
 
     def param_limit
-      params[Config.per_page_param].to_i unless params[Config.per_page_param].nil?
+      params[Config.per_page_param]&.to_i
     end
 
     def includes?(options)

--- a/spec/dummy/app/controllers/dummy_models_total_count_controller.rb
+++ b/spec/dummy/app/controllers/dummy_models_total_count_controller.rb
@@ -1,0 +1,41 @@
+class DummyModelsTotalCountController < ApplicationController
+  include Wor::Paginate
+  include Constants
+
+  def index
+    render_paginated DummyModel, DEFAULT_TOTAL_COUNT
+  end
+
+  def index_scoped
+    render_paginated DummyModel.some_scope.order(:id), DEFAULT_TOTAL_COUNT
+  end
+
+  def index_array
+    render_paginated((1..28).to_a, DEFAULT_TOTAL_COUNT)
+  end
+
+  def index_with_params
+    render_paginated DummyModel, DEFAULT_TOTAL_COUNT.merge(page: 3, limit: 1)
+  end
+
+  def index_with_high_limit
+    render_paginated DummyModel, DEFAULT_TOTAL_COUNT.merge(limit: 125)
+  end
+
+  def index_kaminari
+    render_paginated DummyModel.page(1).per(25), DEFAULT_TOTAL_COUNT
+  end
+
+  def index_will_paginate
+    render_paginated DummyModel.paginate(page: 1, per_page: 25), DEFAULT_TOTAL_COUNT
+  end
+
+  def index_each_serializer
+    render_paginated DummyModel,
+                     DEFAULT_TOTAL_COUNT.merge(each_serializer: ReducedDummyModelSerializer)
+  end
+
+  def index_group_by
+    render_paginated DummyModel.ocurrences_of_name, DEFAULT_TOTAL_COUNT
+  end
+end

--- a/spec/dummy/app/controllers/dummy_models_without_gems_controller.rb
+++ b/spec/dummy/app/controllers/dummy_models_without_gems_controller.rb
@@ -1,5 +1,6 @@
 class DummyModelsWithoutGemsController < ApplicationController
   include Wor::Paginate
+  include Constants
 
   def index
     render_paginated DummyModel
@@ -7,5 +8,13 @@ class DummyModelsWithoutGemsController < ApplicationController
 
   def index_scoped
     render_paginated DummyModel.some_scope
+  end
+
+  def index_total_count
+    render_paginated DummyModel, DEFAULT_TOTAL_COUNT
+  end
+
+  def index_scoped_total_count
+    render_paginated DummyModel.some_scope, DEFAULT_TOTAL_COUNT
   end
 end

--- a/spec/dummy/app/helpers/constants.rb
+++ b/spec/dummy/app/helpers/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  DEFAULT_TOTAL_COUNT = { total_count: 10 }.freeze
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   resources :dummy_models_without_gems, only: [:index] do
     collection do
-      get :index_paginated
+      get 'index_scoped'
+      get 'index_total_count'
+      get 'index_scoped_total_count'
     end
   end
   resources :dummy_models, only: [:index] do

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,4 +32,18 @@ Rails.application.routes.draw do
       get 'index_custom_formatter'
     end
   end
+
+  resources :dummy_models_total_count, only: [:index] do
+    collection do
+      get 'index_array'
+      get 'index_will_paginate'
+      get 'index_kaminari'
+      get 'index_exception'
+      get 'index_scoped'
+      get 'index_with_params'
+      get 'index_with_high_limit'
+      get 'index_each_serializer'
+      get 'index_group_by'
+    end
+  end
 end

--- a/spec/dummy_controller_spec.rb
+++ b/spec/dummy_controller_spec.rb
@@ -4,120 +4,83 @@ describe DummyModelsController, type: :controller do
   describe '#index' do
     let!(:model_count) { 28 }
     let!(:dummy_models) { create_list(:dummy_model, model_count) }
-    let(:expected_list) do
-      dummy_models.first(25).map do |dummy|
-        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-      end
-    end
+    let(:expected_list) { dummy_models.first(25).as_json(only: %i[id name something]) }
 
     context 'when paginating an ActiveRecord with no previous pagination but kaminari installed' do
-      before do
-        get :index
-      end
+      before { get :index }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating with page and limit params' do
       context 'with a particular limit passed by option' do
-        let(:expected_list) do
-          dummy = dummy_models.third
-          [{ 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }]
-        end
+        let(:expected_list) { [dummy_models.third.as_json(only: %i[id name something])] }
         let(:pagination_params) do
           { page: Wor::Paginate::Config.default_page, count: Wor::Paginate::Config.default_page,
             total_count: model_count, total_pages: model_count, previous_page: 2, current_page: 3,
             next_page: 4 }
         end
 
-        before do
-          get :index_with_params
-        end
+        before { get :index_with_params }
 
         include_examples 'proper pagination params'
 
-        it 'responds with valid page' do
-          expect(response_body(response)['page']).to eq expected_list
-        end
+        include_examples 'valid page'
       end
 
       context 'with a really high limit passed by option' do
-        let(:expected_list) do
-          dummy_models.first(50).map do |dummy|
-            { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-          end
-        end
+        let(:expected_list) { dummy_models.first(50).as_json(only: %i[id name something]) }
         let!(:model_count) { 150 }
         let(:pagination_params) do
           { page: 50, count: 50, total_count: model_count, total_pages: 3, previous_page: nil,
             current_page: Wor::Paginate::Config.default_page, next_page: 2 }
         end
 
-        before do
-          get :index_with_high_limit
-        end
+        before { get :index_with_high_limit }
 
         include_examples 'proper pagination params'
 
-        it 'responds with valid page' do
-          expect(response_body(response)['page']).to eq expected_list
-        end
+        include_examples 'valid page'
       end
     end
 
     context 'when paginating an ActiveRecord with a scope' do
-      before do
-        # Requiring both kaminari and will_paginate breaks scope pagination
-        get :index_scoped
-      end
+      # Requiring both kaminari and will_paginate breaks scope pagination
+      before { get :index_scoped }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord paginated with kaminari' do
-      before do
-        get :index_kaminari
-      end
+      before { get :index_kaminari }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord paginated with will_paginate' do
-      before do
-        get :index_will_paginate
-      end
+      before { get :index_will_paginate }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an array' do
-      before do
-        get :index_array
-      end
+      before { get :index_array }
 
       include_context 'with default pagination params'
 
@@ -130,17 +93,15 @@ describe DummyModelsController, type: :controller do
 
     context 'when paginating arrays with param page in -1' do
       it 'throws exception' do
-        expect do
-          get :index_array, params: { page: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
+        expect { get :index_array, params: { page: -1 } }
+          .to raise_error(Wor::Paginate::Exceptions::InvalidPageNumber)
       end
     end
 
     context 'when paginating arrays with per page in -1' do
       it 'throws exception' do
-        expect do
-          get :index_array, params: { per: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidLimitNumber)
+        expect { get :index_array, params: { per: -1 } }
+          .to raise_exception(Wor::Paginate::Exceptions::InvalidLimitNumber)
       end
     end
 
@@ -152,37 +113,21 @@ describe DummyModelsController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord with a custom serializer' do
-      before do
-        get :index_each_serializer
-      end
+      before { get :index_each_serializer }
 
-      let(:expected_list) do
-        dummy_models.first(25).map do |dummy|
-          { 'something' => dummy.something }
-        end
-      end
+      let(:expected_list) { dummy_models.first(25).as_json(only: %i[something]) }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord with a custom formatter' do
-      let(:expected_list) do
-        dummy_models.first(25).map do |dummy|
-          { 'something' => dummy.something,
-            'id' => dummy.id,
-            'name' => dummy.name }
-        end
-      end
+      let(:expected_list) { dummy_models.first(25).as_json(only: %i[id name something]) }
 
-      before do
-        get :index_custom_formatter
-      end
+      before { get :index_custom_formatter }
 
       it 'doesn\'t respond with page in the default key' do
         expect(response_body(response)['page']).to be_nil
@@ -197,12 +142,9 @@ describe DummyModelsController, type: :controller do
       let!(:dummy_models) { create_list(:dummy_model, 1, name: 'argentina') }
       let!(:dummy_models_2) { create_list(:dummy_model, 2, name: 'uruguay') }
       let!(:dummy_models_3) { create_list(:dummy_model, 3, name: 'costa rica') }
-
       let(:limit) { 2 }
 
-      before do
-        get :index_group_by, params: { per: limit }
-      end
+      before { get :index_group_by, params: { per: limit } }
 
       it 'responds with a page with expected length' do
         expect(response_body(response)['page'].length).to eq 2

--- a/spec/dummy_controller_without_gems_spec.rb
+++ b/spec/dummy_controller_without_gems_spec.rb
@@ -1,6 +1,3 @@
-require 'support/shared_context/default_pagination_params'
-require 'support/shared_context/page_two_pag_params'
-require 'support/shared_examples/proper_pagination_params'
 require 'spec_helper'
 
 describe DummyModelsWithoutGemsController, type: :controller do

--- a/spec/dummy_controller_without_gems_spec.rb
+++ b/spec/dummy_controller_without_gems_spec.rb
@@ -147,4 +147,60 @@ describe DummyModelsWithoutGemsController, type: :controller do
       end
     end
   end
+
+  describe '#index_total_count' do
+    let!(:model_count) { 28 }
+    let!(:dummy_models) { create_list(:dummy_model, model_count) }
+    let(:expected_list) do
+      dummy_models.first(25).map do |dummy|
+        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
+      end
+    end
+
+    before do
+      [Wor::Paginate::Adapters::Kaminari, Wor::Paginate::Adapters::WillPaginate].each do |klass|
+        allow_any_instance_of(klass).to receive(:adapt?).and_return(false)
+      end
+    end
+
+    context 'with total_count param' do
+      before do
+        get :index_total_count
+      end
+
+      include_examples 'total count pagination param'
+
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
+      end
+    end
+  end
+
+  describe '#index_scoped_total_count' do
+    let!(:model_count) { 28 }
+    let!(:dummy_models) { create_list(:dummy_model, model_count) }
+    let(:expected_list) do
+      dummy_models.first(25).map do |dummy|
+        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
+      end
+    end
+
+    before do
+      [Wor::Paginate::Adapters::Kaminari, Wor::Paginate::Adapters::WillPaginate].each do |klass|
+        allow_any_instance_of(klass).to receive(:adapt?).and_return(false)
+      end
+    end
+
+    context 'with total_count param' do
+      before do
+        get :index_scoped_total_count
+      end
+
+      include_examples 'total count pagination param'
+
+      it 'responds with valid page' do
+        expect(response_body(response)['page']).to eq expected_list
+      end
+    end
+  end
 end

--- a/spec/dummy_controller_without_gems_spec.rb
+++ b/spec/dummy_controller_without_gems_spec.rb
@@ -149,13 +149,11 @@ describe DummyModelsWithoutGemsController, type: :controller do
   end
 
   describe '#index_total_count' do
-    let!(:model_count) { 28 }
+    subject(:make_request) { get :index_total_count, params: { per: 5 } }
+
+    let!(:model_count) { 9 }
     let!(:dummy_models) { create_list(:dummy_model, model_count) }
-    let(:expected_list) do
-      dummy_models.first(25).map do |dummy|
-        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-      end
-    end
+    let(:expected_list) { dummy_models.first(5).as_json(only: %i[id name something]) }
 
     before do
       [Wor::Paginate::Adapters::Kaminari, Wor::Paginate::Adapters::WillPaginate].each do |klass|
@@ -164,9 +162,7 @@ describe DummyModelsWithoutGemsController, type: :controller do
     end
 
     context 'with total_count param' do
-      before do
-        get :index_total_count
-      end
+      before { make_request }
 
       include_examples 'total count pagination param'
 
@@ -177,13 +173,12 @@ describe DummyModelsWithoutGemsController, type: :controller do
   end
 
   describe '#index_scoped_total_count' do
-    let!(:model_count) { 28 }
+    subject(:make_request) { get :index_scoped_total_count, params: { per: 5 } }
+
+    let(:expected_list) { dummy_models.first(5).as_json(only: %i[id name something]) }
+
+    let!(:model_count) { 9 }
     let!(:dummy_models) { create_list(:dummy_model, model_count) }
-    let(:expected_list) do
-      dummy_models.first(25).map do |dummy|
-        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-      end
-    end
 
     before do
       [Wor::Paginate::Adapters::Kaminari, Wor::Paginate::Adapters::WillPaginate].each do |klass|
@@ -192,9 +187,7 @@ describe DummyModelsWithoutGemsController, type: :controller do
     end
 
     context 'with total_count param' do
-      before do
-        get :index_scoped_total_count
-      end
+      before { make_request }
 
       include_examples 'total count pagination param'
 

--- a/spec/dummy_controller_without_gems_spec.rb
+++ b/spec/dummy_controller_without_gems_spec.rb
@@ -4,11 +4,7 @@ describe DummyModelsWithoutGemsController, type: :controller do
   describe '#index' do
     let!(:model_count) { 28 }
     let!(:dummy_models) { create_list(:dummy_model, model_count) }
-    let(:expected_list) do
-      dummy_models.first(25).map do |dummy|
-        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-      end
-    end
+    let(:expected_list) { dummy_models.first(25).as_json(only: %i[id name something]) }
 
     before do
       [Wor::Paginate::Adapters::Kaminari, Wor::Paginate::Adapters::WillPaginate].each do |klass|
@@ -18,9 +14,8 @@ describe DummyModelsWithoutGemsController, type: :controller do
 
     context 'with param page in -1' do
       it 'throws exception' do
-        expect do
-          get :index, params: { page: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
+        expect { get :index, params: { page: -1 } }
+          .to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
       end
     end
 
@@ -40,37 +35,27 @@ describe DummyModelsWithoutGemsController, type: :controller do
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'with param page in 1' do
-      before do
-        get :index, params: { page: 1 }
-      end
+      before { get :index, params: { page: 1 } }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'without specific page' do
-      before do
-        get :index
-      end
+      before { get :index }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
   end
 
@@ -92,9 +77,8 @@ describe DummyModelsWithoutGemsController, type: :controller do
 
     context 'with param page in -1' do
       it 'throws exception' do
-        expect do
-          get :index, params: { page: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
+        expect { get :index, params: { page: -1 } }
+          .to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
       end
     end
 
@@ -114,37 +98,27 @@ describe DummyModelsWithoutGemsController, type: :controller do
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'with param page in 1' do
-      before do
-        get :index, params: { page: 1 }
-      end
+      before { get :index, params: { page: 1 } }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'without specific page' do
-      before do
-        get :index
-      end
+      before { get :index }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid items' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
   end
 
@@ -166,9 +140,7 @@ describe DummyModelsWithoutGemsController, type: :controller do
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
   end
 
@@ -176,7 +148,6 @@ describe DummyModelsWithoutGemsController, type: :controller do
     subject(:make_request) { get :index_scoped_total_count, params: { per: 5 } }
 
     let(:expected_list) { dummy_models.first(5).as_json(only: %i[id name something]) }
-
     let!(:model_count) { 9 }
     let!(:dummy_models) { create_list(:dummy_model, model_count) }
 
@@ -191,9 +162,7 @@ describe DummyModelsWithoutGemsController, type: :controller do
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
   end
 end

--- a/spec/dummy_models_total_count_controller_spec.rb
+++ b/spec/dummy_models_total_count_controller_spec.rb
@@ -2,12 +2,8 @@ require 'spec_helper'
 
 describe DummyModelsTotalCountController, type: :controller do
   describe '#index' do
-    let!(:dummy_models) { create_list(:dummy_model, 28) }
-    let(:expected_list) do
-      dummy_models.first(25).map do |dummy|
-        { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-      end
-    end
+    let!(:dummy_models) { create_list(:dummy_model, 9) }
+    let(:expected_list) { dummy_models.first(25).as_json(only: %i[id name something]) }
 
     context 'when paginating an ActiveRecord with no previous pagination but kaminari installed' do
       before do
@@ -23,14 +19,9 @@ describe DummyModelsTotalCountController, type: :controller do
 
     context 'when paginating with page and limit params' do
       context 'with a particular limit passed by option' do
-        let(:expected_list) do
-          dummy = dummy_models.third
-          [{ 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }]
-        end
+        let(:expected_list) { [dummy_models.third.as_json(only: %i[id name something])] }
 
-        before do
-          get :index_with_params
-        end
+        before { get :index_with_params }
 
         include_examples 'total count pagination param'
 
@@ -40,15 +31,9 @@ describe DummyModelsTotalCountController, type: :controller do
       end
 
       context 'with a really high limit passed by option' do
-        let(:expected_list) do
-          dummy_models.first(50).map do |dummy|
-            { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-          end
-        end
+        let(:expected_list) { dummy_models.first(50).as_json(only: %i[id name something]) }
 
-        before do
-          get :index_with_high_limit
-        end
+        before { get :index_with_high_limit }
 
         include_examples 'total count pagination param'
 
@@ -59,10 +44,7 @@ describe DummyModelsTotalCountController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord with a scope' do
-      before do
-        # Requiring both kaminari and will_paginate breaks scope pagination
-        get :index_scoped
-      end
+      before { get :index_scoped }
 
       include_examples 'total count pagination param'
 
@@ -72,9 +54,7 @@ describe DummyModelsTotalCountController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord paginated with kaminari' do
-      before do
-        get :index_kaminari
-      end
+      before { get :index_kaminari }
 
       include_examples 'total count pagination param'
 
@@ -84,9 +64,7 @@ describe DummyModelsTotalCountController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord paginated with will_paginate' do
-      before do
-        get :index_will_paginate
-      end
+      before { get :index_will_paginate }
 
       include_examples 'total count pagination param'
 
@@ -96,9 +74,7 @@ describe DummyModelsTotalCountController, type: :controller do
     end
 
     context 'when paginating an array' do
-      before do
-        get :index_array
-      end
+      before { get :index_array }
 
       include_examples 'total count pagination param'
 
@@ -108,15 +84,9 @@ describe DummyModelsTotalCountController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord with a custom serializer' do
-      before do
-        get :index_each_serializer
-      end
+      before { get :index_each_serializer }
 
-      let(:expected_list) do
-        dummy_models.first(25).map do |dummy|
-          { 'something' => dummy.something }
-        end
-      end
+      let(:expected_list) { dummy_models.first(25).as_json(only: %i[something]) }
 
       include_examples 'total count pagination param'
 
@@ -130,9 +100,7 @@ describe DummyModelsTotalCountController, type: :controller do
       let!(:dummy_models_2) { create_list(:dummy_model, 2, name: 'uruguay') }
       let!(:dummy_models_3) { create_list(:dummy_model, 3, name: 'costa rica') }
 
-      before do
-        get :index_group_by, params: { per: 2 }
-      end
+      before { get :index_group_by, params: { per: 2 } }
 
       include_examples 'total count pagination param'
 

--- a/spec/dummy_models_total_count_controller_spec.rb
+++ b/spec/dummy_models_total_count_controller_spec.rb
@@ -6,15 +6,11 @@ describe DummyModelsTotalCountController, type: :controller do
     let(:expected_list) { dummy_models.first(25).as_json(only: %i[id name something]) }
 
     context 'when paginating an ActiveRecord with no previous pagination but kaminari installed' do
-      before do
-        get :index
-      end
+      before { get :index }
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating with page and limit params' do
@@ -25,9 +21,7 @@ describe DummyModelsTotalCountController, type: :controller do
 
         include_examples 'total count pagination param'
 
-        it 'responds with valid page' do
-          expect(response_body(response)['page']).to eq expected_list
-        end
+        include_examples 'valid page'
       end
 
       context 'with a really high limit passed by option' do
@@ -37,9 +31,7 @@ describe DummyModelsTotalCountController, type: :controller do
 
         include_examples 'total count pagination param'
 
-        it 'responds with valid page' do
-          expect(response_body(response)['page']).to eq expected_list
-        end
+        include_examples 'valid page'
       end
     end
 
@@ -48,9 +40,7 @@ describe DummyModelsTotalCountController, type: :controller do
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord paginated with kaminari' do
@@ -58,9 +48,7 @@ describe DummyModelsTotalCountController, type: :controller do
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord paginated with will_paginate' do
@@ -68,9 +56,7 @@ describe DummyModelsTotalCountController, type: :controller do
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an array' do
@@ -90,9 +76,7 @@ describe DummyModelsTotalCountController, type: :controller do
 
       include_examples 'total count pagination param'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord with a group by query' do

--- a/spec/dummy_models_total_count_controller_spec.rb
+++ b/spec/dummy_models_total_count_controller_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
-describe DummyModelsController, type: :controller do
+describe DummyModelsTotalCountController, type: :controller do
   describe '#index' do
-    let!(:model_count) { 28 }
-    let!(:dummy_models) { create_list(:dummy_model, model_count) }
+    let!(:dummy_models) { create_list(:dummy_model, 28) }
     let(:expected_list) do
       dummy_models.first(25).map do |dummy|
         { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
@@ -15,9 +14,7 @@ describe DummyModelsController, type: :controller do
         get :index
       end
 
-      include_context 'with default pagination params'
-
-      include_examples 'proper pagination params'
+      include_examples 'total count pagination param'
 
       it 'responds with valid page' do
         expect(response_body(response)['page']).to eq expected_list
@@ -30,17 +27,12 @@ describe DummyModelsController, type: :controller do
           dummy = dummy_models.third
           [{ 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }]
         end
-        let(:pagination_params) do
-          { page: Wor::Paginate::Config.default_page, count: Wor::Paginate::Config.default_page,
-            total_count: model_count, total_pages: model_count, previous_page: 2, current_page: 3,
-            next_page: 4 }
-        end
 
         before do
           get :index_with_params
         end
 
-        include_examples 'proper pagination params'
+        include_examples 'total count pagination param'
 
         it 'responds with valid page' do
           expect(response_body(response)['page']).to eq expected_list
@@ -53,17 +45,12 @@ describe DummyModelsController, type: :controller do
             { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
           end
         end
-        let!(:model_count) { 150 }
-        let(:pagination_params) do
-          { page: 50, count: 50, total_count: model_count, total_pages: 3, previous_page: nil,
-            current_page: Wor::Paginate::Config.default_page, next_page: 2 }
-        end
 
         before do
           get :index_with_high_limit
         end
 
-        include_examples 'proper pagination params'
+        include_examples 'total count pagination param'
 
         it 'responds with valid page' do
           expect(response_body(response)['page']).to eq expected_list
@@ -77,9 +64,7 @@ describe DummyModelsController, type: :controller do
         get :index_scoped
       end
 
-      include_context 'with default pagination params'
-
-      include_examples 'proper pagination params'
+      include_examples 'total count pagination param'
 
       it 'responds with valid page' do
         expect(response_body(response)['page']).to eq expected_list
@@ -91,9 +76,7 @@ describe DummyModelsController, type: :controller do
         get :index_kaminari
       end
 
-      include_context 'with default pagination params'
-
-      include_examples 'proper pagination params'
+      include_examples 'total count pagination param'
 
       it 'responds with valid page' do
         expect(response_body(response)['page']).to eq expected_list
@@ -105,9 +88,7 @@ describe DummyModelsController, type: :controller do
         get :index_will_paginate
       end
 
-      include_context 'with default pagination params'
-
-      include_examples 'proper pagination params'
+      include_examples 'total count pagination param'
 
       it 'responds with valid page' do
         expect(response_body(response)['page']).to eq expected_list
@@ -119,35 +100,10 @@ describe DummyModelsController, type: :controller do
         get :index_array
       end
 
-      include_context 'with default pagination params'
-
-      include_examples 'proper pagination params'
+      include_examples 'total count pagination param'
 
       it 'responds with valid page' do
         expect(response_body(response)['page']).to eq((1..25).to_a)
-      end
-    end
-
-    context 'when paginating arrays with param page in -1' do
-      it 'throws exception' do
-        expect do
-          get :index_array, params: { page: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
-      end
-    end
-
-    context 'when paginating arrays with per page in -1' do
-      it 'throws exception' do
-        expect do
-          get :index_array, params: { per: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidLimitNumber)
-      end
-    end
-
-    context 'when paginating something that can\'t be paginated' do
-      it 'throws an exception' do
-        expect { get :index_exception }
-          .to raise_error(Wor::Paginate::Exceptions::NoPaginationAdapter)
       end
     end
 
@@ -162,34 +118,10 @@ describe DummyModelsController, type: :controller do
         end
       end
 
-      include_context 'with default pagination params'
-
-      include_examples 'proper pagination params'
+      include_examples 'total count pagination param'
 
       it 'responds with valid page' do
         expect(response_body(response)['page']).to eq expected_list
-      end
-    end
-
-    context 'when paginating an ActiveRecord with a custom formatter' do
-      let(:expected_list) do
-        dummy_models.first(25).map do |dummy|
-          { 'something' => dummy.something,
-            'id' => dummy.id,
-            'name' => dummy.name }
-        end
-      end
-
-      before do
-        get :index_custom_formatter
-      end
-
-      it 'doesn\'t respond with page in the default key' do
-        expect(response_body(response)['page']).to be_nil
-      end
-
-      it 'responds with valid page' do
-        expect(response_body(response)['items']).to eq expected_list
       end
     end
 
@@ -198,18 +130,14 @@ describe DummyModelsController, type: :controller do
       let!(:dummy_models_2) { create_list(:dummy_model, 2, name: 'uruguay') }
       let!(:dummy_models_3) { create_list(:dummy_model, 3, name: 'costa rica') }
 
-      let(:limit) { 2 }
-
       before do
-        get :index_group_by, params: { per: limit }
+        get :index_group_by, params: { per: 2 }
       end
+
+      include_examples 'total count pagination param'
 
       it 'responds with a page with expected length' do
         expect(response_body(response)['page'].length).to eq 2
-      end
-
-      it 'responds with valid total count' do
-        expect(response_body(response)['total_count']).to eq 3
       end
     end
   end

--- a/spec/dummy_sons_controller_spec.rb
+++ b/spec/dummy_sons_controller_spec.rb
@@ -20,17 +20,13 @@ describe DummySonsController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord with no previous pagination but kaminari installed' do
-      before do
-        get :index
-      end
+      before { get :index }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating with page and limit params' do
@@ -54,15 +50,11 @@ describe DummySonsController, type: :controller do
             next_page: 4 }
         end
 
-        before do
-          get :index_with_params
-        end
+        before { get :index_with_params }
 
         include_examples 'proper pagination params'
 
-        it 'responds with valid page' do
-          expect(response_body(response)['page']).to eq expected_list
-        end
+        include_examples 'valid page'
       end
 
       context 'with a really high limit passed by option' do
@@ -86,65 +78,47 @@ describe DummySonsController, type: :controller do
             current_page: Wor::Paginate::Config.default_page, next_page: 2 }
         end
 
-        before do
-          get :index_with_high_limit
-        end
+        before { get :index_with_high_limit }
 
         include_examples 'proper pagination params'
 
-        it 'responds with valid page' do
-          expect(response_body(response)['page']).to eq expected_list
-        end
+        include_examples 'valid page'
       end
     end
 
     context 'when paginating an ActiveRecord with a scope' do
-      before do
-        # Requiring both kaminari and will_paginate breaks scope pagination
-        get :index_scoped
-      end
+      # Requiring both kaminari and will_paginate breaks scope pagination
+      before { get :index_scoped }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord paginated with kaminari' do
-      before do
-        get :index_kaminari
-      end
+      before { get :index_kaminari }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord paginated with will_paginate' do
-      before do
-        get :index_will_paginate
-      end
+      before { get :index_will_paginate }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an array' do
-      before do
-        get :index_array
-      end
+      before { get :index_array }
 
       include_context 'with default pagination params'
 
@@ -157,17 +131,15 @@ describe DummySonsController, type: :controller do
 
     context 'when paginating arrays with param page in -1' do
       it 'throws exception' do
-        expect do
-          get :index_array, params: { page: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
+        expect { get :index_array, params: { page: -1 } }
+          .to raise_exception(Wor::Paginate::Exceptions::InvalidPageNumber)
       end
     end
 
     context 'when paginating arrays with per page in -1' do
       it 'throws exception' do
-        expect do
-          get :index_array, params: { per: -1 }
-        end.to raise_exception(Wor::Paginate::Exceptions::InvalidLimitNumber)
+        expect { get :index_array, params: { per: -1 } }
+          .to raise_exception(Wor::Paginate::Exceptions::InvalidLimitNumber)
       end
     end
 
@@ -179,23 +151,17 @@ describe DummySonsController, type: :controller do
     end
 
     context 'when paginating an ActiveRecord with a custom serializer' do
-      before do
-        get :index_each_serializer
-      end
+      before { get :index_each_serializer }
 
       include_context 'with default pagination params'
 
       include_examples 'proper pagination params'
 
-      it 'responds with valid page' do
-        expect(response_body(response)['page']).to eq expected_list
-      end
+      include_examples 'valid page'
     end
 
     context 'when paginating an ActiveRecord with a custom formatter' do
-      before do
-        get :index_custom_formatter
-      end
+      before { get :index_custom_formatter }
 
       it 'doesn\'t respond with page in the default key' do
         expect(response_body(response)['page']).to be_nil

--- a/spec/dummy_sons_controller_spec.rb
+++ b/spec/dummy_sons_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'support/shared_context/default_pagination_params'
-require 'support/shared_examples/proper_pagination_params'
 require 'spec_helper'
 
 describe DummySonsController, type: :controller do

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 describe DummyModelsController, type: :controller do
   let!(:model_count) { 28 }
   let!(:dummy_models) { create_list(:dummy_model, model_count) }
-  let(:expected_list) do
-    dummy_models.first(25).map do |dummy|
-      { 'id' => dummy.id, 'name' => dummy.name, 'something' => dummy.something }
-    end
-  end
+  let(:expected_list) { dummy_models.first(25).as_json(only: %i[id name something]) }
 
   describe '#be_paginated' do
     context 'when using response_body' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@ require 'simplecov'
 SimpleCov.start
 
 require File.expand_path('../../spec/dummy/config/environment.rb', __FILE__)
-require 'support/response_helper'
 require 'wor/paginate/rspec'
+Dir[File.join('.', 'spec', 'support', '**', '*.rb')].each{ |f| require(f) }
 
 ActiveRecord::Migrator.migrations_paths = [File.expand_path('../../spec/dummy/db/migrate', __FILE__)]
 RSpec.configure do |config|

--- a/spec/support/shared_examples/total_count_pagination_param.rb
+++ b/spec/support/shared_examples/total_count_pagination_param.rb
@@ -1,5 +1,5 @@
 shared_examples 'total count pagination param' do
-  it 'responds with the total_count passed to render_paginated, overrides the real total_count' do
+  it 'responds with the total_count passed to render_paginated, overwrites the real total_count' do
     expect(response_body(response)['total_count']).to(
       be Constants::DEFAULT_TOTAL_COUNT[:total_count]
     )

--- a/spec/support/shared_examples/total_count_pagination_param.rb
+++ b/spec/support/shared_examples/total_count_pagination_param.rb
@@ -1,0 +1,8 @@
+shared_examples 'total count pagination param' do
+  it 'responds with the total_count passed to render_paginated, overrides the real total_count' do
+    expect(response_body(response)['total_count']).to(
+      be Constants::DEFAULT_TOTAL_COUNT[:total_count]
+    )
+    expect(response_body(response)['total_count']).not_to be DummyModel.count
+  end
+end

--- a/spec/support/shared_examples/valid_page.rb
+++ b/spec/support/shared_examples/valid_page.rb
@@ -1,0 +1,5 @@
+shared_examples 'valid page' do
+  it 'responds with valid page' do
+    expect(response_body(response)['page']).to eq expected_list
+  end
+end


### PR DESCRIPTION
## Summary

Overwrite the `total_count` option of the pagination params to optionally pass the query count to the `render_paginated` method and avoid posible crashes due to a complex query.

This PR is related to this issue: https://github.com/Wolox/wor-paginate/issues/77

https://wolox-support.atlassian.net/browse/TPR-35
